### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/BuildManager.java
+++ b/src/BuildManager.java
@@ -138,7 +138,12 @@ public class BuildManager {
                             File newFile = new File(
                                 depClassesPath,
                                 entry.getName()
-                            );
+                            ).getCanonicalFile();
+
+                            // Ensure the new file path is within the intended directory
+                            if (!newFile.toPath().startsWith(depClassesPath.toPath())) {
+                                throw new IOException("Bad zip entry: " + entry.getName());
+                            }
 
                             // Ensure parent directories exist
                             if (entry.isDirectory()) {


### PR DESCRIPTION
Potential fix for [https://github.com/KUKHUA/JSB/security/code-scanning/1](https://github.com/KUKHUA/JSB/security/code-scanning/1)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. This can be done by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory. 

1. Normalize the path of the new file.
2. Check if the normalized path starts with the intended destination directory path.
3. If the check fails, throw an exception to prevent writing the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
